### PR TITLE
Set Java alternatives during setup for Debian

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -21,3 +21,12 @@
     state: present
   with_items: "{{ java_packages }}"
   when: not(ansible_distribution == 'Debian' and ansible_distribution_release == 'jessie' and 'openjdk-8-jdk' in java_packages)
+
+- name: Get openjdk alternative
+  shell: "update-java-alternatives -l | grep openjdk | cut -f -1 -d ' '"
+  changed_when: false
+  register: openjdk_alternative
+
+- name: Set Java alternatives
+  command: "update-java-alternatives -s {{ openjdk_alternative.stdout }}"
+  changed_when: false


### PR DESCRIPTION
Motivations:
If OracleJDK was installed before installing the OpenJDK package on Debian, java symlinks in /etc/alternatives are not updated by the package.

Modifications:
Update java alternatives using `update-java-alternatives` to use OpenJDK instead of OracleJDK.