### PR TITLE
Make the role usable with check-mode

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -21,6 +21,19 @@ provisioner:
     enabled: False
 scenario:
   name: default
+  test_sequence:
+    - lint
+    - destroy
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - check # added to verify --check
+    - side_effect
+    - verify
+    - destroy
 verifier:
   name: testinfra
   lint:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -32,9 +32,8 @@
   shell: "update-java-alternatives -l | grep openjdk | cut -f -1 -d ' '"
   changed_when: false
   register: openjdk_alternative
-  when: not ansible_check_mode
+  check_mode: false
 
 - name: Set Java alternatives
   command: "update-java-alternatives -s {{ openjdk_alternative.stdout }}"
   changed_when: false
-  when: not ansible_check_mode

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -32,7 +32,9 @@
   shell: "update-java-alternatives -l | grep openjdk | cut -f -1 -d ' '"
   changed_when: false
   register: openjdk_alternative
+  when: not ansible_check_mode
 
 - name: Set Java alternatives
   command: "update-java-alternatives -s {{ openjdk_alternative.stdout }}"
   changed_when: false
+  when: not ansible_check_mode


### PR DESCRIPTION
Motivations:
The role was crashing when used with check-mode

Modifications:
* Skip Debian alternatives tasks when running in check-mode
* Add check-mode to molecule test sequence.