### PR TITLE
Add Debian Buster support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,20 @@
 sudo: required
-dist: trusty
+dist: bionic
 
 language: python
 python:
-- '2.7'
-- '3.6'
+- '3.7'
 
 env:
   matrix:
-  - ANSIBLE_REF='ansible<2.6' BASE_IMAGE=debian:stretch
-  - ANSIBLE_REF='ansible<2.5' BASE_IMAGE=debian:stretch
+  - ANSIBLE_REF='ansible~=2.9.0' BASE_IMAGE=debian:stretch
+  - ANSIBLE_REF='ansible~=2.8.0' BASE_IMAGE=debian:stretch
+  - ANSIBLE_REF='ansible~=2.9.0' BASE_IMAGE=debian:buster
+  - ANSIBLE_REF='ansible~=2.8.0' BASE_IMAGE=debian:buster
 
 install:
   - travis_retry pip install --upgrade pip setuptools wheel
-  - travis_retry pip install "${ANSIBLE_REF}" molecule docker-py
+  - travis_retry pip install "${ANSIBLE_REF}" 'molecule==2.22' docker
 
 script:
-  - molecule test --driver-name docker --all
+  - molecule test --all

--- a/README.md
+++ b/README.md
@@ -30,14 +30,10 @@ app_certificates:                # Role default: [], the app can define its own 
 ```
 
 ```yaml
-    keep_oracle_jdk: false
     add_bouncycastle: true
 ```
 
-This role uninstall OracleJDK by default. You can change the
-`keep_oracle_jdk` variable to keep it. This is only available on
-Debian distributions. `add_bouncycastle` can be used to add
-bouncycastle libs to the JDK.
+`add_bouncycastle` can be used to add bouncycastle libs to the JDK.
 
 For bouncycastle you can change the downloaded version and the
 artifacts pulled with :

--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 [![Build Status](https://travis-ci.org/peopledoc/ansible-role-java.svg?branch=master)](https://travis-ci.org/peopledoc/ansible-role-java)
 
-Installs OpenJDK Java for RedHat/CentOS and Debian/Ubuntu linux servers.
-
-## Requirements
-
-None.
+Installs OpenJDK Java for Debian linux servers.
 
 ## Role Variables
 
@@ -20,7 +16,7 @@ Available variables are listed below, along with default values:
 
 
 Set the version/development kit of Java to install, along with any other necessary Java packages.
-By default, it will try to install OpenJDK 8, even if it is not feasible (it will fail, in that case).
+By default, on Debian Buster, Java 11 will be installed. On older Debian, Java 8 will be installed.
 
 CA certificates can be added to the java keystore with the following variables:
 
@@ -60,14 +56,14 @@ None.
 
 ## Dependencies for tests
 
-The dependencies are `ansible`, `molecule` and `docker-py` Python packages.
+The dependencies are `ansible`, `molecule` and `docker` Python packages.
 
 ## Tests
 
 Tests can be executed using:
 
 ```
-$ molecule --debug test --driver-name docker
+$ molecule test --all
 ```
 
 ## License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,6 @@ ca_certificates:
   certificates: "{{ app_certificates + devsecops_ca if devsecops_ca_enabled else app_certificates }}"
   password: "{{ ca_certificates_password }}"
 default_keystore_password: "changeit"
-keep_oracle_jdk: false
 add_bouncycastle: false
 bouncycastle_version: '1.51'
 bouncycastle_artifacts:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,12 +7,8 @@ lint:
   name: yamllint
   enabled: False
 platforms:
-#  - name: molecule_test_instance-debian-9
-#    image: ${BASE_IMAGE:-debian:stretch}
-#  - name: molecule_test_instance-fedora27
-#    image: ${BASE_IMAGE:-fedora:27}
-  - name: molecule_test_instance-debian-8
-    image: ${BASE_IMAGE:-debian:jessie}
+  - name: molecule_test_instance-debian
+    image: ${BASE_IMAGE:-debian:stretch}
 
 provisioner:
   name: ansible

--- a/molecule/java11/molecule.yml
+++ b/molecule/java11/molecule.yml
@@ -7,7 +7,7 @@ lint:
   name: yamllint
   enabled: False
 platforms:
-  - name: molecule_test_instance-debian-8
+  - name: molecule_test_instance-debian
     image: ${BASE_IMAGE:-debian:stretch}
 
 provisioner:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
 
 - name: Download bouncycastle jars in JRE external libs
   get_url:
-    url: 'http://repo2.maven.org/maven2/org/bouncycastle/{{ item }}-jdk15on/{{ bouncycastle_version }}/{{ item }}-jdk15on-{{ bouncycastle_version }}.jar'
+    url: 'https://repo1.maven.org/maven2/org/bouncycastle/{{ item }}-jdk15on/{{ bouncycastle_version }}/{{ item }}-jdk15on-{{ bouncycastle_version }}.jar'
     dest: '{{ java_home }}/{{ jre_lib_location }}/{{ item }}-jdk15on-{{ bouncycastle_version }}.jar'
   with_items: '{{ bouncycastle_artifacts }}'
   when: add_bouncycastle and openjdk_version == 8 and java_home is defined and java_home != ''

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -4,7 +4,7 @@
     name: "{{ oracle_jdk_packages }}"
     state: absent
     purge: true
-  when: oracle_jdk_packages is defined and not keep_oracle_jdk|bool
+  when: oracle_jdk_packages is defined
 
 - name: Add jessie-backports if needed
   apt_repository:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Remove OracleJDK
   apt:
     name: "{{ oracle_jdk_packages }}"
@@ -43,7 +42,7 @@
   when: not(ansible_distribution_release == 'jessie' and 'openjdk-8-jdk' in java_packages) or not(ansible_distribution_release == 'stretch' and 'openjdk-11-jdk' in java_packages)
 
 - name: Get openjdk alternative
-  shell: "update-java-alternatives -l | grep java-1.{{ openjdk_version }}.0-openjdk | cut -f -1 -d ' '"
+  shell: "update-java-alternatives -l | grep java-1.{{ openjdk_version }}.0-openjdk | cut -f -1 -d ' '"
   changed_when: false
   register: openjdk_alternative
   check_mode: false

--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -1,0 +1,11 @@
+---
+# JDK version options include:
+#   - java
+#   - openjdk-8-jdk
+__java_packages:
+  - openjdk-8-jdk
+
+oracle_jdk_packages:
+  - oracle-java8-installer
+  - oracle-java8-set-default
+  - oracle-java8-unlimited-jce-policy

--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -1,9 +1,10 @@
 ---
 # JDK version options include:
 #   - java
-#   - openjdk-8-jdk
+#   - openjdk-11-jdk
+openjdk_version: 11
 __java_packages:
-  - openjdk-8-jdk
+  - openjdk-11-jdk
 
 oracle_jdk_packages:
   - oracle-java8-installer


### PR DESCRIPTION
* Use OpenJDK 11 as the default on Debian Buster
* Update molecule tests to test Debian Buster