### PR TITLE
#17 - Allow to upgrade the version of OpenJDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 /molecule/*/.pytest_cache/
 /molecule/*/pytestdebug.log
 *.pyc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Available variables are listed below, along with default values:
 Set the version/development kit of Java to install, along with any other necessary Java packages.
 By default, on Debian Buster, Java 11 will be installed. On older Debian, Java 8 will be installed.
 
+`java_packages_expected_state` can be used to indicate whether OpenJDK should only be installed or
+if we expect also to have the latest maintenance version. The expected values are "present" or "latest",
+knowing that by default it is set to "present".
+
 CA certificates can be added to the java keystore with the following variables:
 
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,3 +23,4 @@ bouncycastle_artifacts:
   - bcpkix
   - bcprov
 stretch_backports_repository: deb.debian.org
+java_packages_expected_state: present

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -12,12 +12,12 @@
       state: present
   when: ansible_distribution_release == 'jessie' and 'openjdk-8-jdk' in java_packages
 
-- name: Ensure Java is installed (jessie + jdk8).
+- name: Ensure Java is installed and is the latest maintenance version (jessie + jdk8).
   apt:
     name: "{{ java_packages }}"
     default_release: jessie-backports
     update_cache: true
-    state: present
+    state: "{{ java_packages_expected_state }}"
   when: ansible_distribution_release == 'jessie' and 'openjdk-8-jdk' in java_packages
 
 - name: Add stretch-backports if needed
@@ -26,19 +26,19 @@
       state: present
   when: ansible_distribution_release == 'stretch' and 'openjdk-11-jdk' in java_packages
 
-- name: Ensure Java is installed (stretch + jdk11).
+- name: Ensure Java is installed and is the latest maintenance version (stretch + jdk11).
   apt:
     name: "{{ java_packages }}"
     default_release: stretch-backports
     update_cache: true
-    state: present
+    state: "{{ java_packages_expected_state }}"
   when: ansible_distribution == 'Debian' and ansible_distribution_release == 'stretch' and 'openjdk-11-jdk' in java_packages
 
-- name: Ensure Java is installed.
+- name: Ensure Java is installed and is the latest maintenance version .
   apt:
     name: "{{ java_packages }}"
     update_cache: true
-    state: present
+    state: "{{ java_packages_expected_state }}"
   when: not(ansible_distribution_release == 'jessie' and 'openjdk-8-jdk' in java_packages) or not(ansible_distribution_release == 'stretch' and 'openjdk-11-jdk' in java_packages)
 
 - name: Get openjdk alternative


### PR DESCRIPTION
Fix for #17 

## Motivation:
We would like to make sure that we benefit from the latest bug fixes and security patches that we could have since we installed it on our servers by upgrading the maintenance version of OpenJDK 

## Modifications:
Change the expected state used to install the open JDK package to latest to ensure that the latest version is installed. Ref https://docs.ansible.com/ansible/latest/modules/apt_module.html#parameter-state

## Result:
The playbook will install the latest maintenance version of OpenJDK on the target environment, if the variable **java_packages_expected_state** is set to **latest** for a particular environment knowing that by default it is set to **present** indicating that it will only ensure that OpenJDK is installed.